### PR TITLE
Add homebrew-tap PR publish workflow

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,18 @@
+name: Publish formula to homebrew tap
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  update-tap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Homebrew formulae
+        uses: dynamodb-shell-brew-pr-bot/action-homebrew-bump-formula@v3.10.0
+        with:
+          token: "${{ secrets.TOKEN }}"
+          tap: aws/homebrew-tap
+          formula: aws-ddbsh
+          tag: ${{github.event.release.tag_name}}
+          force: true


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
This change adds an automation to automatically open a PR to the [aws/homebrew-tap](https://github.com/aws/homebrew-tap) repository when a new tag is created. The PR is created by the [dynamodb-shell-brew-pr-bot](https://github.com/dynamodb-shell-brew-pr-bot) account. Here is an [example](https://github.com/aws/homebrew-tap/pull/457) of a PR opened by this automation.

In order for the automation to work, the personal access token of that account needs to be added to the [repository secrets](https://github.com/awslabs/dynamodb-shell/settings/secrets/actions/new). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
