### PR TITLE
Correcting CMakeLists path for building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Cloning into 'dynamodb-shell'...
 
 % cd build
 
-% cmake ../ddbsh
+% cmake ../dynamodb-shell/ddbsh
 
 % make
 ```
@@ -153,7 +153,7 @@ Cloning into 'dynamodb-shell'...
 
 % mkdir build && cd build
 
-% cmake ../ddbsh -DCMAKE_BUILD_TYPE=Release
+% cmake ../dynamodb-shell/ddbsh -DCMAKE_BUILD_TYPE=Release
 
 % make
 


### PR DESCRIPTION
cmake ../ddbsh does not exist because the ddbsh is inside dynamodb-shell path (by default of course)

The CMakeLists.txt needed by cmake is in ../dynamodb-shell/ddbsh 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
