### PR TITLE
Use latest action-homebrew-bump-formula release

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update Homebrew formulae
-        uses: dynamodb-shell-brew-pr-bot/action-homebrew-bump-formula@v3.10.0
+        uses: dynamodb-shell-brew-pr-bot/action-homebrew-bump-formula@v3.11.0
         with:
           token: "${{ secrets.TOKEN }}"
           tap: aws/homebrew-tap


### PR DESCRIPTION
This change bumps action-homebrew-bump-formula to the latest version which should fix the error reported by the homebrew publish workflow (`Error: Tapping homebrew/core is no longer typically necessary.`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
