### PR TITLE
Allow homebrew worklow to be triggered manually

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -3,6 +3,7 @@ name: Publish formula to homebrew tap
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   update-tap:


### PR DESCRIPTION
This change allows the homebrew worklow to be triggered manually.
